### PR TITLE
fix: Ingredient row fix

### DIFF
--- a/client/src/pages/createRecipe.js
+++ b/client/src/pages/createRecipe.js
@@ -58,7 +58,11 @@ class CreateRecipe extends React.Component {
       rows: [...this.state.rows, item]
     });
   };
-  handleRemoveSpecificRow = (idx) => () => {
+  handleRemoveSpecificRow = (idx) => () => { 
+    if (idx === 0) {
+      alert("You need atleast 1 ingredient");
+      return
+    }
     const rows = [...this.state.rows]
     rows.splice(idx, 1)
     this.setState({ rows })


### PR DESCRIPTION
Fix an issue where user is allowed to submit no ingredients by removing all the ingredient rows and this was causing the server to break.