### PR TITLE
feat: Added recipe delete button with material design on recipe page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ client/src/pages/user_images/*
 client/src/pages/recipe_images/*
 client/src/pages/config.json
 server/config.json
+.vscode/settings.json

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -27,6 +27,10 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>React App</title>
+
+     <!-- Styles needed for the official material design libraries -->
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"/>
+      <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons"/>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -23,6 +23,7 @@ import AboutUs from './pages/About-Us';
 import EditRecipe from './pages/editRecipe';
 import ExplorePage from './pages/explore';
 import SearchResult from './pages/searchResult';
+import DeleteRecipe from './pages/deleteRecipe';
 
 
 //Sets storage type for session variables
@@ -58,6 +59,7 @@ class App extends Component {
                     <Route path='/recipe/edit/:RecipeID' element={<EditRecipe/>} />
                     <Route path='/explore' element={<ExplorePage/>} />
                     <Route path='/searchResult' element={<SearchResult/>} />
+                    <Route path='/deleteRecipe/:RecipeID' element={<DeleteRecipe/>} />
                 </Routes>
             </Router>
         );

--- a/client/src/pages/deleteRecipe.js
+++ b/client/src/pages/deleteRecipe.js
@@ -1,0 +1,45 @@
+import "../App.css";
+import React, { useState, useEffect } from "react";
+import { ReactSession } from 'react-client-session';
+import { Navigate } from 'react-router-dom';
+import axios from 'axios';
+import {useParams} from "react-router-dom";
+const { serverAddress } = require('./config.json');
+
+function DeleteRecipe() {
+  const [isLoading, setLoading] = useState(true);
+  const {RecipeID} = useParams();
+  
+  ReactSession.set("recipeID",RecipeID);
+
+  useEffect(() => {
+
+    axios.post(serverAddress + "performDelete", {
+      id: ReactSession.get("recipeID")
+    }).then((res) => {
+
+        if (res.data === false) {
+            console.log("False reply from database on recipe page");
+        } else {
+            var output = res.data;
+            console.log(output);
+        }
+      setLoading(false);
+    })
+      .catch((err) => console.log("deleteRecipe.js error: " + err));// eslint-disable-next-line
+  }, []);
+  if (isLoading) {
+    return (
+        <div className="App">Loading...</div>
+    );
+  }
+  else
+  {
+    return (
+      <div className="App">
+        <Navigate to='../explore' />
+      </div>
+    )
+  }
+}
+export default DeleteRecipe;

--- a/client/src/pages/recipe.js
+++ b/client/src/pages/recipe.js
@@ -5,9 +5,12 @@ import "../App.css";
 import axios from 'axios';
 import {useParams} from "react-router-dom";
 import {  Link } from "react-router-dom";
+import Button from '@material-ui/core/Button';
 import Alert from '@mui/material/Alert';
+
 const { serverAddress } = require('./config.json');
-var temp;
+var editTemp;
+var deleteTemp;
 
 //Gets a list of recipes from the backend based on the logged in users username
 function getRecipesByRecipeID()
@@ -72,7 +75,9 @@ function Recipe()
 				});
 				handleAddingredient();
 			}
-			temp = "/recipe/edit/"+ReactSession.get("recipeID");
+			// Creates temp path variables for the edit recipe and delete recipe buttons referenced in the render function
+			editTemp = "/recipe/edit/"+ReactSession.get("recipeID");
+			deleteTemp = "../deleteRecipe/"+ReactSession.get("recipeID");
 			setLoading(false);
 		})
 		.catch((err) => console.log("Recipe.js error: "+err));// eslint-disable-next-line
@@ -106,9 +111,16 @@ function Recipe()
 		    <div className="centered">
 				<h1>{ReactSession.get("recipeName")}</h1>
 
+				{/* Edit recipe button will only appear on the recipe page if the logged in user matches the recipe's owner */}
 				{(ReactSession.get('username') === ReactSession.get("recipeUsername")) &&
-					<Link to={temp} className="profilebuttons">Edit Recipe</Link>
+					<Link to={editTemp} className="profilebuttons">Edit Recipe</Link>
 				}
+
+				{/* Delete button will only appear on the recipe page if the logged in user matches the recipe's owner */}
+				{(ReactSession.get('username') === ReactSession.get("recipeUsername")) &&
+					<a href={deleteTemp}> <Button variant="contained" color="secondary">Delete</Button> </a>
+				}
+
 				<br/><br/>
 				<table className="recipePageTableMain">
 					<tbody>

--- a/server/index.js
+++ b/server/index.js
@@ -664,6 +664,26 @@ app.post("/passwordResetBackend", async (req, res) => {
   });
 });
 
+{/*Performs a delete of a specific recipe based on the given recipeID from the client from both the recipe and ingredients clusters*/}
+app.post("/performDelete", async (req, res) => {
+
+  const output = req.body.id;
+
+  {/*Deletes any ingredients from the ingredient collection which matches supplied recipeID from client*/}
+  IngredientModel.deleteMany({recipeID: output}, function(err, result) {
+      if(err)
+        res.send(err);
+    });
+    
+  {/*Deletes recipe which matches supplied recipeID from client*/}
+  RecipeModel.findOneAndDelete({ _id: output}, function (err, result) {
+    if (err)
+      res.send(false);
+    else
+      res.send(true);
+    }
+  );
+});
 
 {/*Displays running state of server in console, along with the currently running port number*/}
 app.listen(`${port}`, () => {


### PR DESCRIPTION
* Imported needed material design styles to client index.html base file
* Added route to DeleteRecipe page using /deleteRecipe/recipeID as its path using App.js
* Created new file called deleteRecipe.js to allow the easy ability to delete a users recipe by using the same recipeID as the recipe page
* Added redirect after deleting recipe back to explore page
* Added material design delete recipe button to recipe page with corresponding route contained for the deleteRecipe page
* Updated name of temp variable for edit recipe button redirect page
* Added new material design npm packages which will need to be installed before servers running this code will run properly.
* Added performDelete backend function to delete a recipe from both the ingredient model and recipe model when passed a specific recipeID from the client.
* Added comments and removed debugging code for any and all code updated
* Added .vscode to .gitignore

Closes #75 